### PR TITLE
feat: add Mac mini always-on node setup

### DIFF
--- a/MAC-MINI-NODE-GUIDE.md
+++ b/MAC-MINI-NODE-GUIDE.md
@@ -1,0 +1,50 @@
+# Mac mini — Always-On Node Guide
+
+Turn a macOS box (e.g. a headless Mac mini) into an always-on dev/CI node for your fleet: it never sleeps, recovers unattended after a power cut, and runs a self-hosted GitHub Actions runner as a boot-time service.
+
+## Quick start
+
+```bash
+# 1. Always-on power policy + runner (provide URL + a fresh token)
+RUNNER_URL=https://github.com/<owner>/<repo> \
+RUNNER_TOKEN=<token-from-GitHub> \
+  ./scripts/setup-mac-mini-node.sh
+
+# 2. (optional) Xcode for iOS/macOS builds -- uncomment setup_xcode in the
+#    script, or run directly:
+brew install xcodes && xcodes install 26.6
+sudo xcodebuild -runFirstLaunch && sudo xcodebuild -license accept
+sudo xcode-select -s /Applications/Xcode.app
+```
+
+## What it configures
+
+| Area | Setting | Why |
+|---|---|---|
+| Power | `sleep 0`, `displaysleep 0`, `autorestart 1`, `womp 1`, `standby 0`, `disablesleep 1` | never sleeps; reboots after a power cut; wake-on-LAN |
+| Runner | `~/actions-runner` → system LaunchDaemon | starts at boot, runs as your user, no login |
+| Xcode | `xcodes install` | iOS/macOS builds |
+
+## Runner as a boot-time daemon
+
+`setup-mac-mini-node.sh` registers the runner (`config.sh`), installs it as a user LaunchAgent (`svc.sh install`), then `convert-runner-to-daemon.sh` moves that plist into `/Library/LaunchDaemons/` (owned `root:wheel`) and loads it into the system domain. Result: the runner survives any reboot/power-cut with no one logged in.
+
+Get a fresh token (single-use, ~1h) at `<repo> → Settings → Actions → Runners → New self-hosted runner → macOS → ARM64`.
+
+Manage it:
+
+```bash
+sudo launchctl bootout  system/actions.runner.<owner>-<repo>.<name>                 # stop
+sudo launchctl bootstrap system /Library/LaunchDaemons/actions.runner.<...>.plist   # start
+```
+
+## Security notes
+
+- **Only attach self-hosted runners to private repos.** The runner executes arbitrary workflow code — never expose it via public repos or PR-from-fork workflows.
+- `disablesleep 1` keeps the machine fully awake at the cost of a few extra watts.
+- FileVault / auto-login intentionally left OFF: the runner runs at boot as a system daemon, so no login is required for CI.
+
+## See also
+
+- `NODE-SETUP-GUIDE.md` — node-agent fleet setup
+- `scripts/convert-runner-to-daemon.sh` — the daemon-conversion helper

--- a/scripts/convert-runner-to-daemon.sh
+++ b/scripts/convert-runner-to-daemon.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# ============================================================================
+# Convert a configured GitHub Actions runner from a user LaunchAgent
+# (loads at login) to a system LaunchDaemon (starts at boot, runs as the
+# same user, no login required). macOS only. Run AFTER ./svc.sh install.
+# Requires sudo. Generic -- derives the runner label from the plist svc.sh made.
+# ============================================================================
+set -uo pipefail
+
+# Resolve the real user's home even when invoked via sudo.
+TARGET_USER="${SUDO_USER:-$USER}"
+TARGET_HOME="$(dscl . -read "/Users/$TARGET_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+[ -z "$TARGET_HOME" ] && TARGET_HOME="$HOME"
+
+PLIST="$(ls -1 "$TARGET_HOME/Library/LaunchAgents/"actions.runner.*.plist 2>/dev/null | head -1)"
+if [ -z "$PLIST" ]; then
+  echo "No actions.runner.*.plist in $TARGET_HOME/Library/LaunchAgents." >&2
+  echo "Run ./svc.sh install in your runner directory first." >&2
+  exit 1
+fi
+
+LABEL="$(basename "$PLIST" .plist)"
+DST="/Library/LaunchDaemons/$(basename "$PLIST")"
+
+echo "Converting $LABEL -> system LaunchDaemon..."
+mv "$PLIST" "$DST"
+chown root:wheel "$DST"
+chmod 644 "$DST"
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+launchctl bootstrap system "$DST"
+sleep 2
+if launchctl list | grep -q "$LABEL"; then
+  echo "✓ Running in system domain:"
+  launchctl list | grep "$LABEL"
+else
+  echo "⚠ Not listed yet -- check: sudo launchctl print system/$LABEL"
+fi

--- a/scripts/setup-mac-mini-node.sh
+++ b/scripts/setup-mac-mini-node.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# ============================================================================
+# Mac mini — Always-On Node Setup
+# ============================================================================
+# Turns a macOS box (e.g. a headless Mac mini) into an always-on dev/CI node:
+#   1. Power policy: never idle-sleep, restart after a power cut, wake-on-LAN
+#   2. Self-hosted GitHub Actions runner -> boot-time LaunchDaemon
+#      (starts at boot, runs as the current user, no login required)
+#   3. (optional) Xcode via xcodes, for iOS/macOS builds
+#
+# macOS only. Privileged steps call sudo internally. Safe for public use --
+# pass your repo URL + a fresh runner token via env vars; nothing is hardcoded.
+# ============================================================================
+set -e
+export HOME="${HOME:-/root}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- colors / helpers (seed style) ---
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_error()   { echo -e "${RED}✗${NC} $1"; }
+print_info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+print_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+
+# --- gate ---
+if [ "$(uname -s)" != "Darwin" ]; then
+  print_error "This script is macOS-only."
+  exit 1
+fi
+
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
+RUNNER_NAME="${RUNNER_NAME:-$(scutil --get ComputerName 2>/dev/null || echo mac-node)}"
+RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,macOS,ARM64,ios}"
+
+# ============================================================================
+power_policy() {
+  print_info "Applying always-on power policy (sudo)..."
+  sudo pmset -a sleep 0 displaysleep 0 autorestart 1 womp 1 standby 0
+  print_info "Disabling all sleep, incl. maintenance/DarkWake naps (sudo)..."
+  sudo pmset -a disablesleep 1
+  print_success "Power policy applied."
+  pmset -g | grep -E "sleep|displaysleep|autorestart|womp|standby|disablesleep" || true
+}
+
+# ============================================================================
+setup_runner() {
+  if [ -z "${RUNNER_URL:-}" ] || [ -z "${RUNNER_TOKEN:-}" ]; then
+    print_warning "RUNNER_URL / RUNNER_TOKEN not set -- skipping runner setup."
+    print_info "  Get them: <repo> -> Settings -> Actions -> Runners -> New self-hosted runner (macOS, ARM64)."
+    print_info "  Then re-run: RUNNER_URL=https://github.com/<owner>/<repo> RUNNER_TOKEN=... $0"
+    return 0
+  fi
+
+  mkdir -p "$RUNNER_DIR"
+  if [ ! -x "$RUNNER_DIR/runsvc.sh" ]; then
+    print_info "Fetching latest runner (osx-arm64)..."
+    latest=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest \
+             | grep -oE '"tag_name": *"v[^"]+"' | head -1 | sed -E 's/.*"v([^"]+)".*/\1/')
+    curl -fsSL -o "$RUNNER_DIR/runner.tar.gz" \
+      "https://github.com/actions/runner/releases/download/v${latest}/actions-runner-osx-arm64-${latest}.tar.gz"
+    tar xzf "$RUNNER_DIR/runner.tar.gz" -C "$RUNNER_DIR" && rm "$RUNNER_DIR/runner.tar.gz"
+    print_success "Runner v${latest} staged in $RUNNER_DIR."
+  else
+    print_info "Runner already staged in $RUNNER_DIR."
+  fi
+
+  print_info "Registering with $RUNNER_URL (token is single-use, ~1h)..."
+  ( cd "$RUNNER_DIR" && ./config.sh --url "$RUNNER_URL" --token "$RUNNER_TOKEN" \
+       --unattended --labels "$RUNNER_LABELS" --name "$RUNNER_NAME" )
+
+  print_info "Installing as user agent, then converting to a boot-time daemon..."
+  ( cd "$RUNNER_DIR" && ./svc.sh install )
+  sudo bash "$SCRIPT_DIR/convert-runner-to-daemon.sh"
+  print_success "Runner installed as a boot-time daemon."
+  print_info "Verify on GitHub (Idle dot) and locally: sudo launchctl list | grep actions.runner"
+}
+
+# ============================================================================
+setup_xcode() {
+  command -v brew >/dev/null 2>&1 || { print_error "Homebrew required for xcodes."; return 1; }
+  command -v xcodes >/dev/null 2>&1 || brew install xcodes
+  print_info "Installing Xcode ${XCODE_VERSION:-26.6} (prompts for Apple ID + 2FA)..."
+  xcodes install "${XCODE_VERSION:-26.6}"
+  print_info "Post-install (sudo)..."
+  sudo xcodebuild -runFirstLaunch
+  sudo xcodebuild -license accept
+  sudo xcode-select -s /Applications/Xcode.app
+  print_success "Xcode ready."
+}
+
+# ============================================================================
+print_info "Mac mini always-on node setup"
+power_policy
+setup_runner
+# setup_xcode   # uncomment to install Xcode (large; interactive Apple ID)
+
+print_success "Done. See MAC-MINI-NODE-GUIDE.md."


### PR DESCRIPTION
Adds an always-on **macOS node type** to seed: never-sleep power policy, a self-hosted GitHub Actions runner installed as a boot-time system LaunchDaemon (starts at boot, no login), and optional Xcode via xcodes.

- `scripts/setup-mac-mini-node.sh` — macOS-gated setup (power + runner + xcode), parameterized via env vars
- `scripts/convert-runner-to-daemon.sh` — generic user-agent → system-daemon converter
- `MAC-MINI-NODE-GUIDE.md` — runbook

Scrubbed for the public repo (no hardcoded user/repo/token). Aligns with the existing node-agent fleet model.